### PR TITLE
Various fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Backbone and Backbone.Relational and Underscore need to be loaded before this li
     require.config({
         paths : {
             'backbone': 'path/to/backbone',
-            'backbone-relational': 'path/to/bacbone-relational',
+            'backbone-relational': 'path/to/backbone-relational',
             'backbone-relational-jsonapi': 'path/to/backbone-relational-jsonapi'
         }
         shim: {
@@ -35,7 +35,7 @@ To use it, you can require it at your application's boostrap like
         "backbone",
         "backbone-relational",
         "backbone-jsonapi"
-    ], function(Backbone) { 
+    ], function(Backbone) {
         // Your application here
     });
 

--- a/lib/backbone-relational-jsonapi.js
+++ b/lib/backbone-relational-jsonapi.js
@@ -66,11 +66,11 @@
 		if (response.meta && this.handleMeta)
 			this.handleMeta(response.meta);
 
-		var data = response.attributes;
+		var data = response.attributes || {};
 		data.id = response.id;
 
 		if (response.relationships) {
-			var simplifiedRelations = _.mapValues(response.relationships, function(value) {
+			var simplifiedRelations = _.mapObject(response.relationships, function(value) {
 				return value.data;
 			});
 


### PR DESCRIPTION
Hi,

Two fixes in the `parse` method for models:
1. `mapValues` should be `mapObject` because `mapValues` is not an Underscore method.
2. When parsing the attributes, the attributes member on a resource object may not exist so the code needs to handle it not existing. (The JSON-API spec uses the 'MAY' word for the attributes member, which is why it cannot be assumed to always exist.)

Cheers,
Chris
