### PR TITLE
Fixes JSON syntax in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/xbill82/backbone-relational-jsonapi"
-  },
+  }
 }


### PR DESCRIPTION
I tried pulling this down to try it out locally and `npm install` didn't work
