### PR TITLE
put links accessible for model and collection for future use

### DIFF
--- a/lib/backbone-relational-jsonapi.js
+++ b/lib/backbone-relational-jsonapi.js
@@ -35,6 +35,10 @@
 
 	Backbone.modelFactory = new ModelFactory();
 
+	Backbone.Collection.prototype.handleLinks = function(links) {
+		this.links = links;
+		};
+
 	Backbone.Collection.prototype.parse = function(response) {
 		if (!response)
 			return;
@@ -45,6 +49,9 @@
 		if (response.meta && this.handleMeta)
 			this.handleMeta(response.meta);
 
+		if (response.links && this.handleLinks)
+			this.handleLinks(response.links);
+
 		if (!response.data) {
 			return response;
 		}
@@ -52,6 +59,10 @@
 		return response.data;
 	};
 
+	Backbone.RelationalModel.prototype.handleLinks = function(links) {
+			this.links = links;
+	};
+	
 	Backbone.RelationalModel.prototype.parse = function(response) {
 		if (!response)
 			return;
@@ -65,6 +76,9 @@
 
 		if (response.meta && this.handleMeta)
 			this.handleMeta(response.meta);
+
+		if (response.links && this.handleLinks)
+			this.handleLinks(response.links);
 
 		var data = response.attributes || {};
 		data.id = response.id;


### PR DESCRIPTION
I was searching for a simple way to implement link parsing.
And I think the best and simplest way to do it is by using handle function like we do with meta (handleMeta).
This is an implementation of this concept with a default function called handleLinks for RelationalModel and Collection. User can customise it with his custom function but at least we provide a default implementation that can be useful.

Data for testing:
```javascript
{
  "type": "articles",
  "id": "1",
  "attributes": {
    "title": "Rails is Omakase"
  },
  "relationships": {
    "author": {
      "links": {
        "self": "http://example.com/articles/1/relationships/author",
        "related": { "href": "http://example.com/articles/1/author",
                       "meta": {
                                  "count": 10
                                  }
                       }
      },
      "data": { "type": "people", "id": "9" }
    }
  },
  "links": {
    "self": "http://example.com/articles/1"
  }
}
```